### PR TITLE
download data from openneuro instead of openfmri

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Code that attempts to reproduce "A Reproducible MEG/EEG Group Study With the MNE
     conda env create -n reproduction -f environment.yml
     conda activate reproduction
     ```
-5. Extract the events data from MEG files and run linear filtering:
+5. Run linear filtering on MaxFiltered data:
 ```sh
 snakemake all --cores <n>
 ```


### PR DESCRIPTION
- it has both raw (which we don't need) and maxfiltered (which we do need) data,
- no archives involved,
- event are already extracted

Problems:
1. downloads often fail which I solved by running snakemake again and again and again. That could be improved, of course. I haven't found a way to tell snakemake that it should try to re-run failed jobs so, I guess, this has to be done in the rule itself. I am not sure how to correctly catch download problems so that we don't catch something we shouldn't. I looked for a package that could do that for us but haven't found anything.
2. if you ask openneuro for a file that is not in the dataset it will give you a text file that says "no such file in the git repository". We should probably also check for that as well.

We can try to deal with these problems now or create an issue to be dealt with later.